### PR TITLE
Fix/lev man mp

### DIFF
--- a/SOS/include/LocalServerManager.h
+++ b/SOS/include/LocalServerManager.h
@@ -18,7 +18,7 @@ public:
     ~LocalServerManager();
 
     // Start the local server as a thread in the same process
-    bool startEmbeddedServer(int port, LevelManager* levelManager, CollisionManager* collisionManager); // Added parameters
+    bool startEmbeddedServer(int port); // Added parameters
 
     bool stopEmbeddedServer();
 

--- a/SOS/include/LocalServerManager.h
+++ b/SOS/include/LocalServerManager.h
@@ -8,8 +8,6 @@
 
 // Forward declarations
 class EmbeddedServer;
-class LevelManager; // Forward declare LevelManager
-class CollisionManager; // Forward declare CollisionManager
 
 // Class to manage launching and stopping a local game server
 class LocalServerManager {

--- a/SOS/include/game.h
+++ b/SOS/include/game.h
@@ -21,7 +21,6 @@
 #include "network/MultiplayerManager.h"
 #include "LocalServerManager.h"
 #include "player_manager.h"
-#include "level_manager.h"
 
 enum class GameState {
     RUNNING,
@@ -66,9 +65,6 @@ public:
     // Method to add a game object dynamically
     void addObject(std::shared_ptr<Object> object);
     
-    // Level management
-    bool initializeLevel(const std::string& levelId);
-    
     // Static instance getter for singleton access
     static Game* getInstance() { return instance_; }
     static void setInstance(Game* instance) { instance_ = instance; }
@@ -97,9 +93,6 @@ private:
     PlayerInput* input;
     CollisionManager* collisionManager;
     Player* player;
-    
-    // Level management
-    std::unique_ptr<LevelManager> levelManager;
     
     // Local server management
     std::unique_ptr<LocalServerManager> localServerManager;

--- a/SOS/include/level_manager.h
+++ b/SOS/include/level_manager.h
@@ -9,11 +9,10 @@
 #include "level.h"
 #include "collision/CollisionManager.h"
 
-class Game;
 
 class LevelManager {
 public:
-    LevelManager(Game* game, CollisionManager* collisionManager) : game(game), collisionManager(collisionManager){};
+    LevelManager();
     ~LevelManager();
 
     // Initialize the level manager and load all level metadata
@@ -53,7 +52,6 @@ public:
     bool removeAllObjectsFromCurrentLevel();
 
 private:
-    Game* game;
     CollisionManager* collisionManager;
 private:
     std::unordered_map<std::string, std::shared_ptr<Level>> levels_;

--- a/SOS/include/network/EmbeddedServer.h
+++ b/SOS/include/network/EmbeddedServer.h
@@ -77,6 +77,7 @@ private:
     
     // Process player input message
     void processPlayerInput(const std::string& playerId, const NetworkMessage& message);
+    void processPlayerPosition(const std::string& playerId, const NetworkMessage& message);
     
     // Server configuration
     int port_;

--- a/SOS/include/network/EmbeddedServer.h
+++ b/SOS/include/network/EmbeddedServer.h
@@ -29,7 +29,7 @@ class CollisionManager;
  */
 class EmbeddedServer {
 public:
-    EmbeddedServer(int port, LevelManager* levelManager);
+    EmbeddedServer(int port);
     ~EmbeddedServer();
     
     // Start the server
@@ -93,7 +93,7 @@ private:
     // Game state data
     //std::vector<std::shared_ptr<Object>> gameObjects_;
     //std::map<std::string, std::shared_ptr<Player>> players_;
-    LevelManager* levelManager_;
+    std::shared_ptr<LevelManager> levelManager_;
     std::shared_ptr<CollisionManager> collisionManager_;
     
     // Thread management

--- a/SOS/src/LocalServerManager.cpp
+++ b/SOS/src/LocalServerManager.cpp
@@ -23,7 +23,7 @@ LocalServerManager::~LocalServerManager() {
 
 }
 
-bool LocalServerManager::startEmbeddedServer(int port, LevelManager* levelManager, CollisionManager* collisionManager) {
+bool LocalServerManager::startEmbeddedServer(int port) {
     if (serverRunning_) {
         std::cerr << "[LocalServerManager] Server is already running" << std::endl;
         return false;
@@ -34,7 +34,7 @@ bool LocalServerManager::startEmbeddedServer(int port, LevelManager* levelManage
     std::cout << "[LocalServerManager] Starting embedded server on port " << port << std::endl;
     
     try {
-        embeddedServer_ = std::make_unique<EmbeddedServer>(port, levelManager);
+        embeddedServer_ = std::make_unique<EmbeddedServer>(port);
         embeddedServer_->start();
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
         serverRunning_ = true;

--- a/SOS/src/game.cpp
+++ b/SOS/src/game.cpp
@@ -137,7 +137,7 @@ void Game::update(float deltaTime) {
         reconcileWithServerState(deltaTime);
         
         // Update remote players based on server data
-        // updateRemotePlayers(multiplayerManager->getRemotePlayers());
+        updateRemotePlayers(multiplayerManager->getRemotePlayers());
     }
 }
 

--- a/SOS/src/game.cpp
+++ b/SOS/src/game.cpp
@@ -267,10 +267,6 @@ void Game::updateRemotePlayers(const std::map<std::string, std::unique_ptr<Remot
                 (*it)->setvelocity(pair.second->getvelocity());
                 (*it)->setDir(pair.second->getDir());
                 (*it)->setAnimationState(pair.second->getAnimationState());
-
-                std::cout << "[Game] Updated remote player: " << pair.first << std::endl;
-                std::cout << "[Game] Direction: " << static_cast<int>((*it)->getDir()) << std::endl;
-                std::cout << "[Game] Animation state: " << static_cast<int>((*it)->getAnimationState()) << std::endl;
             }
         }
     }

--- a/SOS/src/game.cpp
+++ b/SOS/src/game.cpp
@@ -29,11 +29,7 @@ Game::Game(PlayerInput* input, std::string playerID) : running(true), input(inpu
     multiplayerManager = std::make_unique<MultiplayerManager>();
     
     // Initialize collision manager (used for local prediction only)
-    CollisionManager* collisionManager = new CollisionManager();
-    this->collisionManager = collisionManager;
-    
-    // Initialize LevelManager
-    levelManager = std::make_unique<LevelManager>(this, collisionManager);
+    this->collisionManager = new CollisionManager();;
     
     // Create player using PlayerManager
     auto playerSharedPtr = PlayerManager::getInstance().createPlayer(playerID, Vec2(500, 100));
@@ -143,16 +139,6 @@ void Game::update(float deltaTime) {
         // Update remote players based on server data
         // updateRemotePlayers(multiplayerManager->getRemotePlayers());
     }
-    else {
-        // In single player mode, update the level directly
-        if (levelManager) {
-            // Process player input directly without server
-            player->handleInput(input, deltaTime);
-            
-            // Update the current level (which updates all objects)
-            // levelManager->update(deltaTime);
-        }
-    }
 }
 
 bool Game::isRunning() const {
@@ -172,7 +158,7 @@ bool Game::initializeSinglePlayerEmbeddedServer() {
     std::cout << "[Game] Setting up single player with embedded server" << std::endl;
     
     // Start the embedded server
-    if (!localServerManager->startEmbeddedServer(LOCAL_SERVER_PORT, levelManager.get(), collisionManager)) {
+    if (!localServerManager->startEmbeddedServer(LOCAL_SERVER_PORT)) {
         std::cerr << "[Game] Failed to start embedded server" << std::endl;
         return false;
     }
@@ -183,16 +169,6 @@ bool Game::initializeSinglePlayerEmbeddedServer() {
         std::cerr << "[Game] Failed to connect to embedded server" << std::endl;
         localServerManager->stopEmbeddedServer();
         return false;
-    }
-    
-    // Initialize the first level for single player mode
-    // This will be skipped in multiplayer mode since levels are managed by the server
-    if (!multiplayerActive) {
-        // Initialize the default level (level1)
-        if (!initializeLevel("level1")) {
-            std::cerr << "[Game] Failed to initialize level in single player mode" << std::endl;
-            // Continue anyway, as this might be recoverable
-        }
     }
     
     usingSinglePlayerServer = true;
@@ -384,35 +360,35 @@ void Game::addObject(std::shared_ptr<Object> object) {
     }
 }
 
-// Initialize and load a level
-bool Game::initializeLevel(const std::string& levelId) {
-    if (!levelManager) {
-        std::cerr << "[Game] LevelManager not initialized" << std::endl;
-        return false;
-    }
+// // Initialize and load a level
+// bool Game::initializeLevel(const std::string& levelId) {
+//     if (!levelManager) {
+//         std::cerr << "[Game] LevelManager not initialized" << std::endl;
+//         return false;
+//     }
     
-    // Initialize level manager if not done already
-    if (!levelManager->initialize()) {
-        std::cerr << "[Game] Failed to initialize LevelManager" << std::endl;
-        return false;
-    }
+//     // Initialize level manager if not done already
+//     if (!levelManager->initialize()) {
+//         std::cerr << "[Game] Failed to initialize LevelManager" << std::endl;
+//         return false;
+//     }
     
-    // Load the specified level
-    if (!levelManager->loadLevel(levelId)) {
-        std::cerr << "[Game] Failed to load level: " << levelId << std::endl;
-        return false;
-    }
+//     // Load the specified level
+//     if (!levelManager->loadLevel(levelId)) {
+//         std::cerr << "[Game] Failed to load level: " << levelId << std::endl;
+//         return false;
+//     }
     
-    // Add the player to the level
-    std::string playerId = player->getObjID();
-    if (!levelManager->addPlayerToCurrentLevel(playerId)) {
-        std::cerr << "[Game] Failed to add player to level" << std::endl;
-        return false;
-    }
+//     // Add the player to the level
+//     std::string playerId = player->getObjID();
+//     if (!levelManager->addPlayerToCurrentLevel(playerId)) {
+//         std::cerr << "[Game] Failed to add player to level" << std::endl;
+//         return false;
+//     }
     
-    std::cout << "[Game] Successfully initialized level: " << levelId << std::endl;
-    return true;
-}
+//     std::cout << "[Game] Successfully initialized level: " << levelId << std::endl;
+//     return true;
+// }
 
 void Game::drawMenu(float deltaTime) {
     bool print = false;

--- a/SOS/src/game.cpp
+++ b/SOS/src/game.cpp
@@ -251,6 +251,8 @@ void Game::updateRemotePlayers(const std::map<std::string, std::unique_ptr<Remot
             RemotePlayer* remotePlayer = new RemotePlayer(pair.first);
             remotePlayer->setcollider(pair.second->getcollider());
             remotePlayer->setvelocity(pair.second->getvelocity());
+            remotePlayer->setDir(pair.second->getDir());
+            remotePlayer->setAnimationState(pair.second->getAnimationState());
             objects.push_back(std::shared_ptr<RemotePlayer>(remotePlayer));
         } else {
             if((*it)->getObjID() == player->getObjID())
@@ -263,6 +265,12 @@ void Game::updateRemotePlayers(const std::map<std::string, std::unique_ptr<Remot
                 // Update existing remote player
                 (*it)->setcollider(pair.second->getcollider());
                 (*it)->setvelocity(pair.second->getvelocity());
+                (*it)->setDir(pair.second->getDir());
+                (*it)->setAnimationState(pair.second->getAnimationState());
+
+                std::cout << "[Game] Updated remote player: " << pair.first << std::endl;
+                std::cout << "[Game] Direction: " << static_cast<int>((*it)->getDir()) << std::endl;
+                std::cout << "[Game] Animation state: " << static_cast<int>((*it)->getAnimationState()) << std::endl;
             }
         }
     }

--- a/SOS/src/level.cpp
+++ b/SOS/src/level.cpp
@@ -321,12 +321,15 @@ void Level::setAllEnemiesToTargetPlayer(std::shared_ptr<Player> player) {
     
     // Find all enemies in the level and set the player as their target
     for (auto& object : levelObjects) {
-        // Use dynamic_cast to check if this object is an Enemy
-        std::shared_ptr<Enemy> enemy = std::dynamic_pointer_cast<Enemy>(object);
-        
-        if (enemy) {
-            enemy->setTargetPlayer(player);
-            std::cout << "[Level] Set player as target for enemy: " << object->getObjID() << std::endl;
+        if(object->type == ObjectType::MINOTAUR)
+        {
+            Minotaur* enemy = static_cast<Minotaur*>(object.get());
+            
+            if (enemy) {
+                enemy->setTargetPlayer(player);
+                std::cout << "[Level] Set player as target for enemy: " << object->getObjID() << std::endl;
+            }
         }
+        // Use dynamic_cast to check if this object is an Enemy
     }
 }

--- a/SOS/src/level_manager.cpp
+++ b/SOS/src/level_manager.cpp
@@ -232,9 +232,11 @@ bool LevelManager::addPlayerToCurrentLevel(const std::string& playerId) {
         player = playerManager.createPlayer(playerId, startPos);
     } else {
         // For existing players, update their position to the level's start position
-        player->setposition(startPos);
+        Vec2* playerPos = &player->getcollider().position;
+        playerPos->x = startPos.x;
+        playerPos->y = startPos.y;
         std::cout << "[LevelManager] Repositioned player " << playerId 
-                  << " to level start position: " << startPos.x << "," << startPos.y << std::endl;
+                  << " to level start position: " << playerPos->x << "," << playerPos->y << std::endl;
     }
     
     // Add the player to the current level

--- a/SOS/src/level_manager.cpp
+++ b/SOS/src/level_manager.cpp
@@ -241,6 +241,7 @@ bool LevelManager::addPlayerToCurrentLevel(const std::string& playerId) {
     
     // Add the player to the current level
     currentLevel_->addObject(player);
+    currentLevel_->setAllEnemiesToTargetPlayer(player);
     std::cout << "[LevelManager] Added player " << playerId << " to current level" << std::endl;
     
     return true;

--- a/SOS/src/level_manager.cpp
+++ b/SOS/src/level_manager.cpp
@@ -2,10 +2,16 @@
 #include <nlohmann/json.hpp>
 #include <iostream>
 #include "player_manager.h"
-#include "game.h"
 
 using json = nlohmann::json;
 namespace fs = std::filesystem;
+
+LevelManager::LevelManager()
+{
+    // Initialize the level manager
+    collisionManager = new CollisionManager();
+    currentLevel_ = nullptr;
+}
 
 LevelManager::~LevelManager() {
     // Clean up levels

--- a/SOS/src/network/EmbeddedServer.cpp
+++ b/SOS/src/network/EmbeddedServer.cpp
@@ -603,6 +603,7 @@ void EmbeddedServer::addPlayer(const std::string& playerId) {
         // Create a new player using the PlayerManager singleton
         player = pm.createPlayer(playerId, Vec2{100, 100});
         std::cout << "[EmbeddedServer] Created new player " << playerId << std::endl;
+        levelManager_->addPlayerToCurrentLevel(playerId);
     }
     
     
@@ -902,7 +903,7 @@ void EmbeddedServer::processPlayerInput(
     player->setInput(input.get());
 
     // 5) Immediately invoke the player’s handleInput (or let your game loop do it)
-    player->handleInput(input.get(), /*dtFrames=*/16);
+    player->handleInput(input.get(), 16);
 }
 
 NetworkMessage EmbeddedServer::deserializeMessage(const std::vector<uint8_t>& data, const std::string& clientId) {

--- a/SOS/src/network/EmbeddedServer.cpp
+++ b/SOS/src/network/EmbeddedServer.cpp
@@ -938,10 +938,14 @@ void EmbeddedServer::processPlayerPosition(
 
     // 3) Unpack the position and velocity
     Vec2 pos, vel;
+    FacingDirection dir;
+    AnimationState animState;
     std::memcpy(&pos.x, message.data.data(), sizeof(float));
     std::memcpy(&pos.y, message.data.data() + sizeof(float), sizeof(float));
     std::memcpy(&vel.x, message.data.data() + sizeof(float) * 2, sizeof(float));
     std::memcpy(&vel.y, message.data.data() + sizeof(float) * 3, sizeof(float));
+    std::memcpy(&dir, message.data.data() + sizeof(float) * 4, sizeof(FacingDirection));
+    std::memcpy(&animState, message.data.data() + sizeof(float) * 4 + sizeof(FacingDirection), sizeof(AnimationState));
 
     // 4) Update the player’s position and velocity
     BoxCollider* pColl = &player->getcollider();
@@ -949,6 +953,8 @@ void EmbeddedServer::processPlayerPosition(
     Vec2* velPtr = &player->getvelocity();
     *posPtr = pos;
     *velPtr = vel;
+    player->setDir(dir);
+    player->setAnimationState(animState);
 }
 
 

--- a/SOS/src/network/EmbeddedServer.cpp
+++ b/SOS/src/network/EmbeddedServer.cpp
@@ -835,6 +835,12 @@ void EmbeddedServer::sendGameStateToClients() {
                     stateMsg.data.push_back(static_cast<uint8_t>(mino->getDir()));
                     break;
                 }
+                case ObjectType::PLAYER: {
+                    auto* player = static_cast<Player*>(obj.get());
+                    stateMsg.data.push_back(static_cast<uint8_t>(player->getAnimationState()));
+                    stateMsg.data.push_back(static_cast<uint8_t>(player->getDir()));
+                    break;
+                }
                 
                 default:
                     break;

--- a/SOS/src/network/EmbeddedServer.cpp
+++ b/SOS/src/network/EmbeddedServer.cpp
@@ -15,11 +15,11 @@
 // Buffer size for incoming messages
 constexpr size_t MAX_MESSAGE_SIZE = 1024;
 
-EmbeddedServer::EmbeddedServer(int port, LevelManager* levelManager)
+EmbeddedServer::EmbeddedServer(int port)
     : port_(port), 
       running_(false),
       gameLoopRunning_(false),
-      levelManager_(levelManager),
+      levelManager_(std::make_shared<LevelManager>()),
       collisionManager_(std::make_shared<CollisionManager>()) {
     std::cout << "[EmbeddedServer] Created on port " << port << std::endl;
   

--- a/SOS/src/network/MultiplayerManager.cpp
+++ b/SOS/src/network/MultiplayerManager.cpp
@@ -67,6 +67,22 @@ void RemotePlayer::update(float deltaTime) {
         position_->x += velocity_.x * deltaTime;
         position_->y += velocity_.y * deltaTime;
     }
+    // Set direction based on velocity
+    if (velocity_.x > 0) {
+        setDir(FacingDirection::EAST);
+    } else if (velocity_.x < 0) {
+        setDir(FacingDirection::WEST);
+    } else if (velocity_.y > 0) {
+        setDir(FacingDirection::NORTH);
+    } else if (velocity_.y < 0) {
+        setDir(FacingDirection::SOUTH);
+    }
+    // Update animation state based on velocity
+    if (velocity_.length() > 0) {
+        setAnimationState(AnimationState::WALKING);
+    } else {
+        setAnimationState(AnimationState::IDLE);
+    }
 
     // Update the object's position
     setcollider(BoxCollider(*position_, getcollider().size));

--- a/SOS/src/network/MultiplayerManager.cpp
+++ b/SOS/src/network/MultiplayerManager.cpp
@@ -18,19 +18,26 @@ RemotePlayer::RemotePlayer(const std::string& id)
       targetPosition_(Vec2(0, 0)),
       targetVelocity_(Vec2(0, 0)) {
     
-    addSpriteSheet(AnimationState::IDLE, new SpriteData("Idle_fem", 96, 128, 8), 250, true);
+    addSpriteSheet(AnimationState::IDLE, new SpriteData("wolfman_idle", 128, 128, 2), 200, true);
     // addAnimation(AnimationState::IDLE, 0, 1, getCurrentSpriteData()->columns, 250, true);        // Idle animation (1 frames)
     animController.setDirectionRow(AnimationState::IDLE, FacingDirection::NORTH, 0);
     animController.setDirectionRow(AnimationState::IDLE, FacingDirection::WEST, 1);
     animController.setDirectionRow(AnimationState::IDLE, FacingDirection::SOUTH, 2);
     animController.setDirectionRow(AnimationState::IDLE, FacingDirection::EAST, 3);
 
-    addSpriteSheet(AnimationState::WALKING, new SpriteData("player_walking", 128, 128, 9), 150, true);
+    addSpriteSheet(AnimationState::WALKING, new SpriteData("wolfman_walk", 128, 128, 8), 150, true);
     // addAnimation(AnimationState::WALKING, 0, 8, 9, 150, true);      // Walking animation (3 frames)
     animController.setDirectionRow(AnimationState::WALKING, FacingDirection::NORTH, 0);
     animController.setDirectionRow(AnimationState::WALKING, FacingDirection::WEST, 1);
     animController.setDirectionRow(AnimationState::WALKING, FacingDirection::SOUTH, 2);
     animController.setDirectionRow(AnimationState::WALKING, FacingDirection::EAST, 3);
+
+    addSpriteSheet(AnimationState::ATTACKING, new SpriteData("wolfman_slash", 384, 384, 5), 80, false);
+
+    animController.setDirectionRow(AnimationState::ATTACKING, FacingDirection::NORTH, 0);
+    animController.setDirectionRow(AnimationState::ATTACKING, FacingDirection::WEST, 1);
+    animController.setDirectionRow(AnimationState::ATTACKING, FacingDirection::SOUTH, 2);
+    animController.setDirectionRow(AnimationState::ATTACKING, FacingDirection::EAST, 3);
 
     // Set initial state
     setAnimationState(AnimationState::IDLE);
@@ -439,9 +446,16 @@ void MultiplayerManager::processGameState(const std::vector<uint8_t>& gameStateD
                     it = remotePlayers_.emplace(objectId, std::move(newPlayer)).first;
                     std::cout << "[Client] Created new remote player: " << objectId << std::endl;
                 }
+
+                AnimationState state = static_cast<AnimationState>(gameStateData[pos++]);
+                FacingDirection dir = static_cast<FacingDirection>(gameStateData[pos++]);
+
                 
                 // Update remote player state
                 RemotePlayer* player = it->second.get();
+                
+                player->setDir(dir);
+                player->setAnimationState(state);
                 player->setTargetPosition(Vec2(posX, posY));
                 player->setTargetVelocity(Vec2(velX, velY));
                 player->resetInterpolation();

--- a/SOS/src/network/MultiplayerManager.cpp
+++ b/SOS/src/network/MultiplayerManager.cpp
@@ -178,7 +178,7 @@ void MultiplayerManager::update(float deltaTime) {
     network_->update();
     
     static uint64_t lastUpdateTime = 0;
-    lastUpdateTime += deltaTime*1000;  // Convert to milliseconds
+    lastUpdateTime += static_cast<uint64_t>(deltaTime*1000);  // Convert to milliseconds
 
     // Update all remote players
     for (auto& pair : remotePlayers_) {
@@ -192,6 +192,7 @@ void MultiplayerManager::update(float deltaTime) {
     // Send player input periodically (primary control method now)
     if (playerInput_ && localPlayer_ && lastUpdateTime >= NetworkConfig::Client::UpdateInterval) {
         sendPlayerInput();
+        sendPlayerState();
         lastUpdateTime_ = deltaTime;
     }
 }
@@ -218,7 +219,7 @@ void MultiplayerManager::sendPlayerState() {
     posMsg.type = MessageType::PLAYER_POSITION;
     posMsg.senderId = playerId_;
     posMsg.data = serializePlayerState(localPlayer_);
-    
+
     network_->sendMessage(posMsg);
 }
 
@@ -426,9 +427,9 @@ void MultiplayerManager::processGameState(const std::vector<uint8_t>& gameStateD
         switch (static_cast<ObjectType>(objectType)) {
             case ObjectType::PLAYER: { // Player
                 // Skip if this is our local player
-                if (objectId == playerId_) {
-                    // Position and velocity are already handled by the local player and reconciliation
-                }
+                // if (objectId == playerId_) {
+                //     // Position and velocity are already handled by the local player and reconciliation
+                // }
                 
                 // Find or create remote player
                 auto it = remotePlayers_.find(objectId);

--- a/SOS/src/network/MultiplayerManager.cpp
+++ b/SOS/src/network/MultiplayerManager.cpp
@@ -595,6 +595,10 @@ std::vector<uint8_t> MultiplayerManager::serializePlayerState(const Player* play
     // Copy velocity (8 bytes)
     std::memcpy(&data[8], &vel.x, sizeof(float));
     std::memcpy(&data[12], &vel.y, sizeof(float));
+
+    // Add direction and animation state
+    data.push_back(static_cast<uint8_t>(player->getDir()));
+    data.push_back(static_cast<uint8_t>(player->getAnimationState()));
     
     return data;
 }

--- a/SOS/src/network/MultiplayerManager.cpp
+++ b/SOS/src/network/MultiplayerManager.cpp
@@ -67,22 +67,6 @@ void RemotePlayer::update(float deltaTime) {
         position_->x += velocity_.x * deltaTime;
         position_->y += velocity_.y * deltaTime;
     }
-    // Set direction based on velocity
-    if (velocity_.x > 0) {
-        setDir(FacingDirection::EAST);
-    } else if (velocity_.x < 0) {
-        setDir(FacingDirection::WEST);
-    } else if (velocity_.y > 0) {
-        setDir(FacingDirection::NORTH);
-    } else if (velocity_.y < 0) {
-        setDir(FacingDirection::SOUTH);
-    }
-    // Update animation state based on velocity
-    if (velocity_.length() > 0) {
-        setAnimationState(AnimationState::WALKING);
-    } else {
-        setAnimationState(AnimationState::IDLE);
-    }
 
     // Update the object's position
     setcollider(BoxCollider(*position_, getcollider().size));

--- a/SOS/src/objects/player.cpp
+++ b/SOS/src/objects/player.cpp
@@ -80,12 +80,8 @@ void Player::update(float deltaTime) {
     Vec2* pos = &pColl->position;
     Vec2 vel = getvelocity();
 
-    // Prints velocity.y every second
-    static uint64_t timems = 0.0f;
-    timems += deltaTime;
 
-    pos->x += vel.x * deltaTime;
-    pos->y += vel.y * deltaTime;
+    *pos += vel * deltaTime; // Update position based on velocity and delta time
 
 
     // Set direction based on horizontal and vertical velocity

--- a/SOS/src/objects/player.cpp
+++ b/SOS/src/objects/player.cpp
@@ -120,9 +120,6 @@ void Player::update(float deltaTime) {
     // updateAnimation(deltaTime*1000); // Convert deltaTime to milliseconds
     Entity::update(deltaTime); // Call base class update
 
-    vel.x = 0; // Reset horizontal velocity
-    vel.y = 0; // Reset vertical velocity
-
     setvelocity(vel); // Update velocity
     setcollider(*pColl); // Update position
 }

--- a/SOS/src/objects/player.cpp
+++ b/SOS/src/objects/player.cpp
@@ -134,15 +134,13 @@ void Player::update(float deltaTime) {
 void Player::handleInput(PlayerInput* input, float deltaTime) {
 
     // Handle player input here
-    Vec2 vel = getvelocity();
+    Vec2 vel(0,0);
 
     float movementSpeed = 300.0f; // Set movement speed
 
     if (input->get_left()) {
         vel.x = -movementSpeed; // Move left
-    }
-    if (input->get_right()) {
-        // std::cout << "get_right" << std::endl;
+    } else if (input->get_right()) {
         vel.x = movementSpeed; // Move right
     }
     if (input->get_down()) {
@@ -157,7 +155,7 @@ void Player::handleInput(PlayerInput* input, float deltaTime) {
         isAttacking = true;
         attackTimer = 0;
     }
-
+    // std::cout << "Player velocity: " << vel.x << ", " << vel.y << std::endl;
     setvelocity(vel);
 }
 

--- a/SOS/src/objects/tile.cpp
+++ b/SOS/src/objects/tile.cpp
@@ -4,6 +4,7 @@ Tile::Tile(int x, int y, std::string objID, std::string tileMap, int tileIndex, 
     // Initialize Tile-specific attributes here
     SpriteData* spriteData = new SpriteData(tileMap, tileWidth, tileHeight, columns);
     addSpriteSheet(AnimationState::IDLE, spriteData, 250, true, tileIndex);
+    addAnimation(AnimationState::IDLE, tileIndex, 1, columns, 250, true);
 
 }
 


### PR DESCRIPTION
#Changes
- Removed levelmanager from client-side code
- Added in player position updates on server-side to make player positien client authorative
- Client now sends over player animationstate and facingdirection
- Removed velocity reset at end of player update, velocity goes to 0 if no input is given
- Removed use of playermanager in Game() class because it conflicted on singeplayermode because of the singleton

#TODO
- Connection handling in-game without needing terminal commands
- Removing player objects after player_disconnect